### PR TITLE
修复 SqlMap-Oracle模板使用了TOP关键字的问题

### DIFF
--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-GetRecord.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-GetRecord.cshtml
@@ -11,5 +11,7 @@
 <!--获取记录数-->
 <Statement Id="GetRecord">
     Select Count(1) From @table.Name T
-    <Include RefId="QueryParams" />
+    <Where>
+        <Include RefId="QueryParams" />
+    </Where>
 </Statement>

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-IsExist.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-IsExist.cshtml
@@ -8,6 +8,8 @@
 <!--是否存在该记录-->
 <Statement Id="IsExist">
     Select Count(1) From @table.Name T
-    <Include RefId="QueryParams" />
+    <Where>
+        <Include RefId="QueryParams" />
+    </Where>
 </Statement>
 

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-Query.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-Query.cshtml
@@ -19,10 +19,12 @@
 
 <!--获取数据列-->
 <Statement Id="Query" @queryStatementResultMap>
-    SELECT 
-    <Include RefId="AllCols"/>
+    SELECT
+    <Include RefId="AllCols" />
     From @table.Name T
-    <Include RefId="QueryParams" />
+    <Where>
+        <Include RefId="QueryParams" />
+    </Where>
     <Switch Prepend="Order By" Property="OrderBy">
         <Default>
             T.@pkCol.Name Desc

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-QueryByPage.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/CURD/SqlMap-QueryByPage.cshtml
@@ -21,16 +21,18 @@
 @section QueryByPage
     {
     <!--获取分页数据-->
-    <Statement Id="QueryByPage" @queryStatementResultMap>
-        Select 
-        <Include RefId="AllCols"/>
-        From @table.Name As T
+<Statement Id="QueryByPage" @queryStatementResultMap>
+    Select
+    <Include RefId="AllCols" />
+    From @table.Name As T
+    <Where>
         <Include RefId="QueryParams" />
-        <Switch Prepend="Order By" Property="OrderBy">
-            <Default>
-                T.@pkCol.Name Desc
-            </Default>
-        </Switch>
-        Limit  @(dbPrefix)PageSize Offset @(dbPrefix)Offset
-    </Statement>
+    </Where>
+    <Switch Prepend="Order By" Property="OrderBy">
+        <Default>
+            T.@pkCol.Name Desc
+        </Default>
+    </Switch>
+    Limit  @(dbPrefix)PageSize Offset @(dbPrefix)Offset
+</Statement>
 }

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-MySql.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-MySql.cshtml
@@ -22,17 +22,19 @@
 @section QueryByPage
     {
     <!--获取分页数据-->
-    <Statement Id="QueryByPage" @(queryStatementResultMap)>
-        Select 
-        <Include RefId="AllCols"/>
-        From @table.Name As T
+<Statement Id="QueryByPage" @(queryStatementResultMap)>
+    Select
+    <Include RefId="AllCols" />
+    From @table.Name As T
+    <Where>
         <Include RefId="QueryParams" />
-        <Switch Prepend="Order By" Property="OrderBy">
-            <Default>
-                T.@pkCol.Name Desc
-            </Default>
-        </Switch>
-        Limit @(dbPrefix)Offset,@(dbPrefix)PageSize
-    </Statement>
+    </Where>
+    <Switch Prepend="Order By" Property="OrderBy">
+        <Default>
+            T.@pkCol.Name Desc
+        </Default>
+    </Switch>
+    Limit @(dbPrefix)Offset,@(dbPrefix)PageSize
+</Statement>
 }
 

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-Oracle.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-Oracle.cshtml
@@ -26,7 +26,10 @@
     <Statement Id="QueryByPage" @queryStatementResultMap>
         Select TT.* From
         (Select ROW_NUMBER() Over(Order By T.@pkCol.Name Desc) Row_Index,T.* From @table.Name T
-        <Include RefId="QueryParams" />) TT
+        <Where>
+            <Include RefId="QueryParams" />
+        </Where>
+        ) TT
         Where TT.Row_Index Between ((@@PageIndex-1)*@@PageSize+1) And (@@PageIndex*@@PageSize)
     </Statement>
 }
@@ -37,26 +40,22 @@
         Select T.* From @table.Name T
         <Where Min="1">
             ROWNUM = 1
-        @foreach (var col in table.Columns)
-        {
-            <IsNotEmpty Prepend="And" Property="@col.ConvertedName">
-                T.@col.Name= @($"{dbPrefix}{col.ConvertedName}")
-            </IsNotEmpty>
-        }
+            <Include RefId="QueryParams" />
         </Where>
     </Statement>
 }
 
 @section Query
-    {
+{
     <!--获取数据列-->
     <Statement Id="Query" @queryStatementResultMap>
-        SELECT
-        <IsNotEmpty Prepend="Top" Property="Taken">
-            (@(dbPrefix)Taken)
-        </IsNotEmpty>
-        T.* From @table.Name T
-        <Include RefId="QueryParams" />
+        SELECT T.* From @table.Name T
+        <Where Min="1">
+            <IsNotEmpty Prepend="AND" Property="Taken">
+                <![CDATA[ROWNUM <= @(dbPrefix)Taken]]>
+            </IsNotEmpty>
+            <Include RefId="QueryParams" />
+        </Where>
         <Switch Prepend="Order By" Property="OrderBy">
             <Default>
                 T.@pkCol.Name Desc

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-PostgreSql.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-PostgreSql.cshtml
@@ -24,17 +24,19 @@
 @section QueryByPage
     {
     <!--获取分页数据-->
-    <Statement Id="QueryByPage" @queryStatementResultMap>
-        Select 
-        <Include RefId="AllCols"/>
-        From @table.Name As T
+<Statement Id="QueryByPage" @queryStatementResultMap>
+    Select
+    <Include RefId="AllCols" />
+    From @table.Name As T
+    <Where>
         <Include RefId="QueryParams" />
-        <Switch Prepend="Order By" Property="OrderBy">
-            <Default>
-                T.@pkCol.Name Desc
-            </Default>
-        </Switch>
-        Limit @(dbPrefix)PageSize Offset @(dbPrefix)Offset
-    </Statement>
+    </Where>
+    <Switch Prepend="Order By" Property="OrderBy">
+        <Default>
+            T.@pkCol.Name Desc
+        </Default>
+    </Switch>
+    Limit @(dbPrefix)PageSize Offset @(dbPrefix)Offset
+</Statement>
 }
 

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-SQLite.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-SQLite.cshtml
@@ -22,16 +22,18 @@
 @section QueryByPage
     {
     <!--获取分页数据-->
-    <Statement Id="QueryByPage" @queryStatementResultMap>
-        Select 
-        <Include RefId="AllCols"/>
-        From @table.Name As T
+<Statement Id="QueryByPage" @queryStatementResultMap>
+    Select
+    <Include RefId="AllCols" />
+    From @table.Name As T
+    <Where>
         <Include RefId="QueryParams" />
-        <Switch Prepend="Order By" Property="OrderBy">
-            <Default>
-                T.@pkCol.Name Desc
-            </Default>
-        </Switch>
-        Limit @(dbPrefix)PageSize Offset @(dbPrefix)Offset
-    </Statement>
+    </Where>
+    <Switch Prepend="Order By" Property="OrderBy">
+        <Default>
+            T.@pkCol.Name Desc
+        </Default>
+    </Switch>
+    Limit @(dbPrefix)PageSize Offset @(dbPrefix)Offset
+</Statement>
 }

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-SqlServer.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/SqlMap-SqlServer.cshtml
@@ -32,28 +32,32 @@
 @section QueryByPage
 {
     <!--获取分页数据-->
-    <Statement Id="QueryByPage" @queryStatementResultMap>
-        @if (versionNo >= 2012)
-        {
-            <text>
-                Select 
-                <Include RefId="AllCols"/>
-                From @table.Name T With(NoLock)
-                <Include RefId="QueryParams"/>
-                Order By T.@pkCol.Name Desc
-                Offset ((@(dbPrefix)PageIndex-1)*@(dbPrefix)PageSize) Rows Fetch Next @(dbPrefix)PageSize Rows Only;
-            </text>
-        }
-        else
-        {
-            <text>
-                Select TT.* From
-                (Select ROW_NUMBER() Over(Order By T.@pkCol.Name Desc) Row_Index,T.* From @table.Name T With(NoLock)
-                <Include RefId="QueryParams"/>) TT
-                Where TT.Row_Index Between ((@(dbPrefix)PageIndex-1)*@(dbPrefix)PageSize+1) And (@(dbPrefix)PageIndex*@(dbPrefix)PageSize);
-            </text>
-        }
-    </Statement>
+<Statement Id="QueryByPage" @queryStatementResultMap>
+    @if (versionNo >= 2012)
+    {
+        <text>
+            Select
+            <Include RefId="AllCols" />
+            From @table.Name T With(NoLock)
+            <Where>
+                <Include RefId="QueryParams" />
+            </Where>
+            Order By T.@pkCol.Name Desc
+            Offset ((@(dbPrefix)PageIndex-1)*@(dbPrefix)PageSize) Rows Fetch Next @(dbPrefix)PageSize Rows Only;
+        </text>
+    }
+    else
+    {
+        <text>
+            Select TT.* From
+            (Select ROW_NUMBER() Over(Order By T.@pkCol.Name Desc) Row_Index,T.* From @table.Name T With(NoLock)
+            <Where>
+                <Include RefId="QueryParams" />
+            </Where>) TT
+            Where TT.Row_Index Between ((@(dbPrefix)PageIndex-1)*@(dbPrefix)PageSize+1) And (@(dbPrefix)PageIndex*@(dbPrefix)PageSize);
+        </text>
+    }
+</Statement>
 }
 
 @section GetEntity
@@ -82,9 +86,11 @@
         <IsNotEmpty Prepend="Top" Property="Taken">
             (@(dbPrefix)Taken)
         </IsNotEmpty>
-        <Include RefId="AllCols"/>
+        <Include RefId="AllCols" />
         From @table.Name T
-        <Include RefId="QueryParams"/>
+        <Where>
+            <Include RefId="QueryParams" />
+        </Where>
         <Switch Prepend="Order By" Property="OrderBy">
             <Default>
                 T.@pkCol.Name Desc

--- a/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/_SqlMapLayout.cshtml
+++ b/src/SmartCode.Generator/RazorTemplates/CSharp/SqlMap-Partials/_SqlMapLayout.cshtml
@@ -18,15 +18,13 @@
     @{ await Html.RenderPartialAsync("SqlMap-ResultMaps.cshtml", Model); }
     <Statements>
         @{ await Html.RenderPartialAsync("SqlMap-Columns.cshtml", Model); }
-        <Statement Id="QueryParams">
-            <Where>
-                @foreach (var col in table.Columns)
-                {
-                    <IsNotEmpty Prepend="And" Property="@col.ConvertedName">
-                        T.@col.Name = @dbPrefix@col.ConvertedName
-                    </IsNotEmpty>
-                }
-            </Where>
+        <Statement Id="QueryParams">            
+            @foreach (var col in table.Columns)
+            {
+                <IsNotEmpty Prepend="And" Property="@col.ConvertedName">
+                    T.@col.Name = @dbPrefix@col.ConvertedName
+                </IsNotEmpty>
+            }            
         </Statement>
 
         @if (IsSectionDefined("Insert"))


### PR DESCRIPTION
修复 SqlMap-Oracle模板使用了TOP关键字的问题，需要的SmartSql修复 93号Issue 后可正常使用。