### PR TITLE
Update to netcoreapp3.1

### DIFF
--- a/src/SmartCode.App/SmartCode.App.csproj
+++ b/src/SmartCode.App/SmartCode.App.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="1.10.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SmartCode.ETL\SmartCode.ETL.csproj" />

--- a/src/SmartCode.CLI/SmartCode.CLI.csproj
+++ b/src/SmartCode.CLI/SmartCode.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>SmartCode</ToolCommandName>
@@ -14,11 +14,11 @@
     </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartCode.Db/SmartCode.Db.csproj
+++ b/src/SmartCode.Db/SmartCode.Db.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SmartSql.Options" Version="4.1.50" />
-    <PackageReference Include="SmartSql.TypeHandler" Version="4.1.50" />
-    <PackageReference Include="SmartSql.TypeHandler.PostgreSql" Version="4.1.50" />
+    <PackageReference Include="SmartSql.Options" Version="4.1.53" />
+    <PackageReference Include="SmartSql.TypeHandler" Version="4.1.53" />
+    <PackageReference Include="SmartSql.TypeHandler.PostgreSql" Version="4.1.53" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
-    <PackageReference Include="MySql.Data" Version="8.0.19" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
+    <PackageReference Include="MySql.Data" Version="8.0.20" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartCode.ETL.LoadToES/SmartCode.ETL.LoadToES.csproj
+++ b/src/SmartCode.ETL.LoadToES/SmartCode.ETL.LoadToES.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NEST" Version="6.4.1" />
+    <PackageReference Include="NEST" Version="6.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartCode.ETL.PostgreSql/SmartCode.ETL.PostgreSql.csproj
+++ b/src/SmartCode.ETL.PostgreSql/SmartCode.ETL.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SmartCode.ETL.SQLite/SmartCode.ETL.SQLite.csproj
+++ b/src/SmartCode.ETL.SQLite/SmartCode.ETL.SQLite.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartCode.ETL/SmartCode.ETL.csproj
+++ b/src/SmartCode.ETL/SmartCode.ETL.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SmartSql.Bulk.MySql" Version="4.1.52" />
-    <PackageReference Include="SmartSql.Bulk.PostgreSql" Version="4.1.52" />
-    <PackageReference Include="SmartSql.Bulk.SqlServer" Version="4.1.52" />
+    <PackageReference Include="SmartSql.Bulk.MySql" Version="4.1.53" />
+    <PackageReference Include="SmartSql.Bulk.PostgreSql" Version="4.1.53" />
+    <PackageReference Include="SmartSql.Bulk.SqlServer" Version="4.1.53" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SmartCode.Generator/SmartCode.Generator.csproj
+++ b/src/SmartCode.Generator/SmartCode.Generator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SmartCode.TemplateEngine/SmartCode.TemplateEngine.csproj
+++ b/src/SmartCode.TemplateEngine/SmartCode.TemplateEngine.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="1.10.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SmartCode.Tests/DbTypeConverter_Test.cs
+++ b/src/SmartCode.Tests/DbTypeConverter_Test.cs
@@ -15,7 +15,7 @@ namespace SmartCode.Tests
         [Fact]
         public void Convert()
         {
-            var xmlPath = @"E:\Ahoo\SmartCode\src\SmartCode\DbTypeConverter\DbTypeMap.xml";
+            var xmlPath = @"E:\projects\SmartCode\src\SmartCode\DbTypeConverter\DbTypeMap.xml";
             var patamters = new Dictionary<string, object> {
                 { "XmlPath",xmlPath}
             };

--- a/src/SmartCode.Tests/DbTypeConverter_Test.cs
+++ b/src/SmartCode.Tests/DbTypeConverter_Test.cs
@@ -15,14 +15,14 @@ namespace SmartCode.Tests
         [Fact]
         public void Convert()
         {
-            var xmlPath = @"E:\projects\SmartCode\src\SmartCode\DbTypeConverter\DbTypeMap.xml";
+            var xmlPath = @"E:\projects\SmartCode\src\SmartCode.CLI\bin\Debug\netcoreapp3.1\DbTypeConverter\DbTypeMap.xml";
             var patamters = new Dictionary<string, object> {
                 { "XmlPath",xmlPath}
             };
             IDbTypeConverter convert = new DefaultDbTypeConverter(NullLogger<DefaultDbTypeConverter>.Instance);
             convert.Initialize(patamters);
             var langType = convert.LanguageType(DbProvider.SqlServer, "CSharp", "int");
-            Assert.Equal("Int16", langType);
+            Assert.Equal("int", langType);
         }
     }
 }

--- a/src/SmartCode.Tests/SmartCode.Tests.csproj
+++ b/src/SmartCode.Tests/SmartCode.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/SmartCode.Tests/YamlBuilder_Test.cs
+++ b/src/SmartCode.Tests/YamlBuilder_Test.cs
@@ -10,7 +10,7 @@ namespace SmartCode.Tests
         [Fact]
         public void Build()
         {
-            var configPath = @"E:\Ahoo\SmartCode\doc\SmartCode.yml";
+            var configPath = @"E:\projects\SmartCode\doc\SmartCode.yml";
             YamlBuilder yamlBuilder = new YamlBuilder(configPath);
             var project = yamlBuilder.Build();
         }

--- a/src/SmartCode/SmartCode.csproj
+++ b/src/SmartCode/SmartCode.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Title>SmartCode</Title>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="YamlDotNet" Version="8.1.0" />
-    <PackageReference Include="SmartSql" Version="4.1.50" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="SmartSql" Version="4.1.53" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
主程序更新为 netcoreapp3.1
其他类库更新为 netstandard2.1

所使用组件除 NEST 只更新到 6.8.6 以外(最新版本为7.7.1)，其他组件均更新到最新版本。