### PR TITLE
添加并行构建功能，添加依赖任务配置

### DIFF
--- a/src/SmartCode.App/PluginManager.cs
+++ b/src/SmartCode.App/PluginManager.cs
@@ -56,19 +56,23 @@ namespace SmartCode.App
             var plugins = _serviceProvider.GetServices<TPlugin>();
             foreach (var plugin in plugins)
             {
-                if (!plugin.Initialized)
+                lock (this)
                 {
-                    var pluginType = plugin.GetType();
-                    var names = pluginType.AssemblyQualifiedName.Split(',');
-                    var typeName = names[0].Trim();
-                    var assName = names[1].Trim();
-                    var pluginConfig = _smartCodeOptions
-                        .Plugins
-                        .FirstOrDefault(m => m.ImplAssemblyName == assName && m.ImplTypeName == typeName);
-                    plugin.Initialize(pluginConfig.Parameters);
+                    if (!plugin.Initialized)
+                    {
+                        var pluginType = plugin.GetType();
+                        var names = pluginType.AssemblyQualifiedName.Split(',');
+                        var typeName = names[0].Trim();
+                        var assName = names[1].Trim();
+                        var pluginConfig = _smartCodeOptions
+                            .Plugins
+                            .FirstOrDefault(m => m.ImplAssemblyName == assName && m.ImplTypeName == typeName);
+                        plugin.Initialize(pluginConfig.Parameters);
+                    }
                 }
             }
             return plugins;
+
         }
     }
 }

--- a/src/SmartCode.CLI/Program.cs
+++ b/src/SmartCode.CLI/Program.cs
@@ -12,9 +12,11 @@ namespace SmartCode.CLI
 {
     class Program
     {
-        static async Task  Main(string[] args)
+        static async Task Main(string[] args)
         {
-           await CommandLineApplication.ExecuteAsync<SmartCodeCommand>(args);
+            ThreadPool.SetMinThreads(1000, 1000);
+            ThreadPool.SetMaxThreads(1000, 1000);
+            await CommandLineApplication.ExecuteAsync<SmartCodeCommand>(args);
         }
     }
 }

--- a/src/SmartCode.Generator/GeneratorProjectBuilder.cs
+++ b/src/SmartCode.Generator/GeneratorProjectBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,6 @@ namespace SmartCode.Generator
         private readonly Project _project;
         private readonly IPluginManager _pluginManager;
         private readonly ILogger<GeneratorProjectBuilder> _logger;
-        private CountdownEvent countdown = new CountdownEvent(1);
 
         public GeneratorProjectBuilder(
             Project project
@@ -23,29 +23,69 @@ namespace SmartCode.Generator
             _logger = logger;
         }
 
+        CountdownEvent countdown = new CountdownEvent(1);
 
         public async Task Build()
         {
             var dataSource = _pluginManager.Resolve<IDataSource>(_project.DataSource.Name);
             await dataSource.InitData();
 
-            this.countdown.Reset();
-            foreach (var buildKV in _project.BuildTasks)
+            //foreach (var buildKV in _project.BuildTasks)
+            //{
+            //    _logger.LogInformation($"-------- BuildTask:{buildKV.Key} Start! ---------");
+            //    var output = buildKV.Value.Output;
+            //    var buildContext = new BuildContext
+            //    {
+            //        PluginManager = _pluginManager,
+            //        Project = _project,
+            //        DataSource = dataSource,
+            //        BuildKey = buildKV.Key,
+            //        Build = buildKV.Value,
+            //        Output = output?.Copy()
+            //    };
+            //    await _pluginManager.Resolve<IBuildTask>(buildKV.Value.Type).Build(buildContext);
+            //    _logger.LogInformation($"-------- BuildTask:{buildKV.Key} End! ---------");
+            //}
+            BuildContext[] contexts = _project.BuildTasks.Select(d => new BuildContext
             {
-                _logger.LogInformation($"-------- BuildTask:{buildKV.Key} Start! ---------");
-                var output = buildKV.Value.Output;
-                var buildContext = new BuildContext
-                {
-                    PluginManager = _pluginManager,
-                    Project = _project,
-                    DataSource = dataSource,
-                    BuildKey = buildKV.Key,
-                    Build = buildKV.Value,
-                    Output = output?.Copy()
-                };
-                await _pluginManager.Resolve<IBuildTask>(buildKV.Value.Type).Build(buildContext);
-                _logger.LogInformation($"-------- BuildTask:{buildKV.Key} End! ---------");
+                PluginManager = _pluginManager,
+                Project = _project,
+                DataSource = dataSource,
+                BuildKey = d.Key,
+                Build = d.Value,
+                Output = d.Value.Output?.Copy(),
+            }).ToArray();
+            foreach (var context in contexts)
+            {
+                context.DependOn = contexts.Where(d => d.Build.DependOn.Contains(d.BuildKey)).ToArray();
             }
+            countdown.Reset();
+            foreach (var context in contexts)
+            {
+                context.BuildTask = Task.Factory.StartNew(this.BuildTask, null, TaskCreationOptions.LongRunning);
+            }
+
+            countdown.Signal();
+        }
+        private async void BuildTask(object obj)
+        {
+            countdown.Wait();
+            var context = (BuildContext)obj;
+            _logger.LogInformation($"-------- BuildTask:{context.BuildKey} Wait! ---------");
+            //等待依赖任务
+            if (context.DependOn != null)
+            {
+                foreach (var dcontext in context.DependOn)
+                {
+                    await dcontext.BuildTask;
+                }
+            }
+
+            _logger.LogInformation($"-------- BuildTask:{context.BuildKey} Start! ---------");
+            //执行自身任务
+            await _pluginManager.Resolve<IBuildTask>(context.Build.Type).Build(context);
+
+            _logger.LogInformation($"-------- BuildTask:{context.BuildKey} End! ---------");
         }
     }
 }

--- a/src/SmartCode.Generator/GeneratorProjectBuilder.cs
+++ b/src/SmartCode.Generator/GeneratorProjectBuilder.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SmartCode.Configuration;
@@ -9,6 +11,7 @@ namespace SmartCode.Generator
         private readonly Project _project;
         private readonly IPluginManager _pluginManager;
         private readonly ILogger<GeneratorProjectBuilder> _logger;
+        private CountdownEvent countdown = new CountdownEvent(1);
 
         public GeneratorProjectBuilder(
             Project project
@@ -23,25 +26,49 @@ namespace SmartCode.Generator
 
         public async Task Build()
         {
-            BuildContext buildContext = null;
             var dataSource = _pluginManager.Resolve<IDataSource>(_project.DataSource.Name);
             await dataSource.InitData();
+
+            this.countdown.Reset();
             foreach (var buildKV in _project.BuildTasks)
             {
-                _logger.LogInformation($"-------- BuildTask:{buildKV.Key} Start! ---------");
-                var output = buildKV.Value.Output;
-                buildContext = new BuildContext
+                if (!buildKV.Value.WaitPre)
                 {
-                    PluginManager = _pluginManager,
-                    Project = _project,
-                    DataSource = dataSource,
-                    BuildKey = buildKV.Key,
-                    Build = buildKV.Value,
-                    Output = output?.Copy()
-                };
-                await _pluginManager.Resolve<IBuildTask>(buildKV.Value.Type).Build(buildContext);
-                _logger.LogInformation($"-------- BuildTask:{buildKV.Key} End! ---------");
+                    this.countdown.AddCount();
+                    Thread t = new Thread((obj) =>
+                    {
+                        var p = ((KeyValuePair<string, Build> buildKV, IDataSource dataSource))obj;
+                        BuildTask(buildKV, dataSource);
+                        this.countdown.Signal();
+                    });
+
+                    t.Start((buildKV, dataSource));
+                    continue;
+                }
+
+                this.countdown.Signal();
+                this.countdown.Wait();
+                this.countdown.Reset();
+
+                BuildTask(buildKV, dataSource);
             }
+        }
+
+        private void BuildTask(KeyValuePair<string, Build> buildKV, IDataSource dataSource)
+        {
+            _logger.LogInformation($"-------- BuildTask:{buildKV.Key} Start! ---------");
+            var output = buildKV.Value.Output;
+            BuildContext buildContext = new BuildContext
+            {
+                PluginManager = _pluginManager,
+                Project = _project,
+                DataSource = dataSource,
+                BuildKey = buildKV.Key,
+                Build = buildKV.Value,
+                Output = output?.Copy()
+            };
+            _pluginManager.Resolve<IBuildTask>(buildKV.Value.Type).Build(buildContext).Wait();
+            _logger.LogInformation($"-------- BuildTask:{buildKV.Key} End! ---------");
         }
     }
 }

--- a/src/SmartCode/BuildContext.cs
+++ b/src/SmartCode/BuildContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using SmartCode.Configuration;
 
@@ -8,6 +9,7 @@ namespace SmartCode
 {
     public class BuildContext
     {
+
         public Project Project { get; set; }
         public IDataSource DataSource { get; set; }
         public IPluginManager PluginManager { get; set; }
@@ -28,7 +30,8 @@ namespace SmartCode
             Items[key] = item;
         }
 
-        public IEnumerable<BuildContext> DependOn { get; set; }
-        public Task BuildTask { get; set; }
+        public IList<BuildContext> DependOn { get; set; }
+        //public Task BuildTask { get; set; }
+        public CountdownEvent CountDown { get; } = new CountdownEvent(1);
     }
 }

--- a/src/SmartCode/BuildContext.cs
+++ b/src/SmartCode/BuildContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using SmartCode.Configuration;
 
 namespace SmartCode
@@ -26,5 +27,9 @@ namespace SmartCode
         {
             Items[key] = item;
         }
+
+        public IEnumerable<BuildContext> DependOn { get; set; }
+        public IEnumerable<BuildContext> Next { get; set; }
+        public Task BuildTask { get; set; }
     }
 }

--- a/src/SmartCode/BuildContext.cs
+++ b/src/SmartCode/BuildContext.cs
@@ -29,7 +29,6 @@ namespace SmartCode
         }
 
         public IEnumerable<BuildContext> DependOn { get; set; }
-        public IEnumerable<BuildContext> Next { get; set; }
         public Task BuildTask { get; set; }
     }
 }

--- a/src/SmartCode/Configuration/Build.cs
+++ b/src/SmartCode/Configuration/Build.cs
@@ -13,13 +13,17 @@ namespace SmartCode.Configuration
         /// </summary>
         public String Type { get; set; }
         public String Module { get; set; }
-        public TemplateEngine TemplateEngine { get; set; } 
+        public TemplateEngine TemplateEngine { get; set; }
         public Output Output { get; set; }
         public IEnumerable<String> IncludeTables { get; set; }
         public IEnumerable<String> IgnoreTables { get; set; }
         public bool? IgnoreNoPKTable { get; set; }
         public bool? IgnoreView { get; set; }
         public NamingConverter NamingConverter { get; set; }
+        /// <summary>
+        /// 依赖于
+        /// </summary>
+        public IEnumerable<String> DependOn { get; set; }
         /// <summary>
         /// 自定义构建参数
         /// </summary>

--- a/src/SmartCode/Configuration/Build.cs
+++ b/src/SmartCode/Configuration/Build.cs
@@ -21,10 +21,6 @@ namespace SmartCode.Configuration
         public bool? IgnoreView { get; set; }
         public NamingConverter NamingConverter { get; set; }
         /// <summary>
-        /// 是否等待前序任务
-        /// </summary>
-        public bool WaitPre { get; set; } = true;
-        /// <summary>
         /// 自定义构建参数
         /// </summary>
         public IDictionary<String, object> Parameters { get; set; }

--- a/src/SmartCode/Configuration/Build.cs
+++ b/src/SmartCode/Configuration/Build.cs
@@ -21,6 +21,10 @@ namespace SmartCode.Configuration
         public bool? IgnoreView { get; set; }
         public NamingConverter NamingConverter { get; set; }
         /// <summary>
+        /// 是否等待前序任务
+        /// </summary>
+        public bool WaitPre { get; set; } = true;
+        /// <summary>
         /// 自定义构建参数
         /// </summary>
         public IDictionary<String, object> Parameters { get; set; }

--- a/src/SmartCode/Configuration/Project.cs
+++ b/src/SmartCode/Configuration/Project.cs
@@ -11,6 +11,7 @@ namespace SmartCode.Configuration
         public String ConfigPath { get; set; }
         public String Module { get; set; }
         public String Author { get; set; }
+        public bool AllowParallel { get; set; } = false;
         public ProjectMode? Mode { get; set; }
         public DataSource DataSource { get; set; }
         public TemplateEngine TemplateEngine { get; set; } = TemplateEngine.Default;


### PR DESCRIPTION
可以为每个Build任务配置WaitPre属性。当WaitPre为True 时，会等待前面的所有任务完成后，再执行当前任务。当WaitPre为false时，会开启新线程来执行BUILD，以榨干CPU性能。当没有配置WaitPre时，默认为True。

构建速度在4核心CPU上提升20% 以上。CPU逻辑核心越多，提升越大。