### PR TITLE
升级MySql.Data版本到8.0.29

### DIFF
--- a/src/SmartCode.Db/SmartCode.Db.csproj
+++ b/src/SmartCode.Db/SmartCode.Db.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="SmartSql.TypeHandler.PostgreSql" Version="4.1.50" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
-    <PackageReference Include="MySql.Data" Version="8.0.19" />
+    <PackageReference Include="MySql.Data" Version="8.0.29" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
   </ItemGroup>


### PR DESCRIPTION
升级MySql.Data版本，修复读取information_schema不支持utf8mb3的问题